### PR TITLE
Fix search

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -38,6 +38,7 @@ export default function SearchBar({ handleUrl }) {
                             type="text"
                             className="curso"
                             placeholder="6D"
+                            required
                             name="curso"
                             value={curso}
                             onChange={handleInputChange}

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -51,6 +51,7 @@ export default function SearchBar({ handleUrl }) {
                             type="text"
                             className="periodo"
                             placeholder="2020-2021"
+                            required
                             name="periodo"
                             value={periodo}
                             onChange={handleInputChange}

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -61,7 +61,7 @@ export default function SearchBar({ handleUrl }) {
                     <label class="col-md-4 col-sm-6">
                         <span>Ordenar</span>
                         <select id="filter" className="dropdown">
-                            <option value="num-lista">Número (Defecto)</option>
+                            <option value="num-lista" selected>Número (Defecto)</option>
                             <option value="idx-academico">Indice Académico</option>
                             <option value="idx-tecnico">Indice Técnico</option>
                             <option value="idx-general">Indice General</option>


### PR DESCRIPTION
**Cambios**

1. Soluciona el problema que se ocasionaba al no rellenar los campos del SearchBar (input Curso y input Periodo).
2. Selecciona como default la primera opción (Número) del Select / filter.